### PR TITLE
feat: generalize git workflow and docs rules for Copilot

### DIFF
--- a/src/.chezmoitemplates/ai-instructions/documentation.md
+++ b/src/.chezmoitemplates/ai-instructions/documentation.md
@@ -1,0 +1,8 @@
+## Documentation and comments
+
+- Keep docs, comments, and commit messages pithy -- state the current fact,
+  not the history of how I got there. Don't leave remnants of a wrong
+  turn (a claim I made and then had to correct, a rejected approach, "note:
+  earlier this said X but that was wrong") in shipped text. If that history
+  is genuinely worth keeping, keep it in the conversation or commit history --
+  not in the artifact itself.

--- a/src/.chezmoitemplates/ai-instructions/git-workflow.md
+++ b/src/.chezmoitemplates/ai-instructions/git-workflow.md
@@ -26,3 +26,5 @@
 - After a commit+push, if there's no more queued work on that branch, switch
   back to `main` (and `git pull`) rather than leaving the session sitting on a
   finished feature branch.
+- Never add a `Co-Authored-By` trailer (or any other AI-attribution line) to
+  commit messages -- author commits as mine alone.

--- a/src/.chezmoitemplates/ai-instructions/git-workflow.md
+++ b/src/.chezmoitemplates/ai-instructions/git-workflow.md
@@ -1,21 +1,3 @@
-<!-- WARNING: This file is chezmoi-managed and should not be manually edited! -->
-# CLAUDE.md
-
-## Where to save durable knowledge
-
-Before saving something you learn (workflow rules, gotchas, established
-patterns -- not one-off task context) to persistent memory, ask which of
-these it belongs in, rather than guessing:
-
-- **Private local memory** -- tied to one project, not shared with the team
-  or other tools.
-- **The project's `AGENTS.md`** -- version-controlled, shared with the team
-  and interoperable across coding agents; for conventions specific to that
-  project. If a `CLAUDE.md` file doesn't exist yet, make one that imports
-  `AGENTS.md` as well.
-- **This file** -- applies to every project you personally work in, but
-  private to you and invisible to teammates or other tools.
-
 ## Git workflow
 
 - Default to a feature branch + PR for any change -- do not commit directly to
@@ -44,12 +26,3 @@ these it belongs in, rather than guessing:
 - After a commit+push, if there's no more queued work on that branch, switch
   back to `main` (and `git pull`) rather than leaving the session sitting on a
   finished feature branch.
-
-## Documentation and comments
-
-- Keep docs, comments, and commit messages pithy -- state the current fact,
-  not the history of how I got there. Don't leave remnants of a wrong
-  turn (a claim I made and then had to correct, a rejected approach, "note:
-  earlier this said X but that was wrong") in shipped text. If that history
-  is genuinely worth keeping, it belongs in session memory, not in the
-  artifact itself.

--- a/src/.chezmoitemplates/vscode/reusable-settings/core.json
+++ b/src/.chezmoitemplates/vscode/reusable-settings/core.json
@@ -7,6 +7,9 @@
     },
     "breadcrumbs.enabled": true,
     "chat.editor.wordWrap": "on",
+    "chat.instructionsFilesLocations": {
+        "~/.config/copilot/instructions": true
+    },
     "chat.restoreLastPanelSession": true,
     "claudeCode.preferredLocation": "sidebar",
     "diffEditor.codeLens": true,

--- a/src/dot_config/claude/CLAUDE.md.tmpl
+++ b/src/dot_config/claude/CLAUDE.md.tmpl
@@ -1,0 +1,20 @@
+<!-- WARNING: This file is chezmoi-managed and should not be manually edited! -->
+# CLAUDE.md
+
+## Where to save durable knowledge
+
+Before saving something you learn (workflow rules, gotchas, established
+patterns -- not one-off task context) to persistent memory, ask which of
+these it belongs in, rather than guessing:
+
+- **Private local memory** -- tied to one project, not shared with the team
+  or other tools.
+- **The project's `AGENTS.md`** -- version-controlled, shared with the team
+  and interoperable across coding agents; for conventions specific to that
+  project. If a `CLAUDE.md` file doesn't exist yet, make one that imports
+  `AGENTS.md` as well.
+- **This file** -- applies to every project you personally work in, but
+  private to you and invisible to teammates or other tools.
+
+{{ include ".chezmoitemplates/ai-instructions/git-workflow.md" }}
+{{ include ".chezmoitemplates/ai-instructions/documentation.md" -}}

--- a/src/dot_config/copilot/instructions/global.instructions.md.tmpl
+++ b/src/dot_config/copilot/instructions/global.instructions.md.tmpl
@@ -1,0 +1,23 @@
+---
+applyTo: '**'
+---
+<!-- WARNING: This file is chezmoi-managed and should not be manually edited! -->
+
+## Where to save durable knowledge
+
+Before saving something you learn (workflow rules, gotchas, established
+patterns -- not one-off task context), ask which of these it belongs in,
+rather than guessing -- and prefer one of these over letting Copilot Memory
+pick it up passively, since Memory is unavailable in VS Code's Copilot Chat
+and auto-expires unused entries after 28 days anyway:
+
+- **The project's `AGENTS.md`** -- version-controlled, shared with the team
+  and interoperable across coding agents; for conventions specific to that
+  project. Create it if it doesn't exist yet, and if a `CLAUDE.md` file
+  doesn't exist yet either, make one that imports `AGENTS.md` too, staged
+  for future interoperability with other coding agents.
+- **This file** -- applies to every project you personally work in, but
+  private to you and invisible to teammates or other tools.
+
+{{ include ".chezmoitemplates/ai-instructions/git-workflow.md" }}
+{{ include ".chezmoitemplates/ai-instructions/documentation.md" -}}


### PR DESCRIPTION
Extract the tool-agnostic Git workflow and documentation rules from CLAUDE.md into a shared .chezmoitemplates partial, included from both CLAUDE.md and a new global Copilot instructions file. The latter also tells Copilot to prefer writing durable project knowledge to AGENTS.md over relying on Copilot Memory (passive, auto-expiring, and unavailable in VS Code's Copilot Chat anyway), and to stage a CLAUDE.md importing AGENTS.md when one doesn't exist yet, for interoperability if the project is later opened in Claude Code.

The instructions file is picked up by Copilot CLI via $COPILOT_HOME and by VS Code's in-editor Copilot Chat via a new
chat.instructionsFilesLocations entry in core.json (confirmed against the vscode-copilot-chat source, since some web docs describe an unrelated Agent Skills feature at similar-looking paths).